### PR TITLE
Bugfix/fix text format

### DIFF
--- a/src/utils/adfUtils.ts
+++ b/src/utils/adfUtils.ts
@@ -1,0 +1,37 @@
+/**
+ * Utility to ensure the description field is in Atlassian Document Format (ADF).
+ * If received an object already in ADF format, returns as is.
+ * If received a string, converts to a simple doc ADF.
+ */
+export function toADF(description: any): any {
+    if (!description) return {
+        type: "doc",
+        version: 1,
+        content: [ { type: "paragraph", content: [] } ]
+    };
+    // If already an object of type doc ADF
+    if (typeof description === "object" && description.type === "doc" && description.version === 1 && Array.isArray(description.content)) {
+        return description;
+    }
+    // If string, convert to basic ADF
+    if (typeof description === "string") {
+        return {
+            type: "doc",
+            version: 1,
+            content: [
+                {
+                    type: "paragraph",
+                    content: [
+                        { type: "text", text: description }
+                    ]
+                }
+            ]
+        };
+    }
+    // Fallback
+    return {
+        type: "doc",
+        version: 1,
+        content: [ { type: "paragraph", content: [] } ]
+    };
+}

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -63,12 +63,25 @@ export const JiraCheckUserIssuesRequestSchema = JiraApiRequestSchema.shape({
 export const JiraCreateIssueRequestSchema = JiraApiRequestSchema.shape({
     projectKey: yup.string().required("Project key is required"),
     summary: yup.string().required("Issue summary/title is required"),
-    description: yup.string().required("Issue description is required"),
+    description: yup.mixed()
+        .test('is-string-or-adf', 'Issue description must be a string or an Atlassian Document Format object', value => {
+            if (typeof value === 'string') return true;
+            if (typeof value === 'object' && value !== null) {
+                return (
+                    'type' in value && value.type === 'doc' &&
+                    'version' in value && value.version === 1 &&
+                    'content' in value && Array.isArray((value as any).content)
+                );
+            }
+            return false;
+        })
+        .required("Issue description is required"),
     issueType: yup.string().oneOf(['Task', 'Bug', 'Story', 'Epic'], "Issue type must be one of: Task, Bug, Story, Epic").default("Task"),
     assigneeName: yup.string(),
     reporterName: yup.string(),
     sprintId: yup.string(),
 });
+
 
 /**
  * Schema for validating Jira sprint query requests


### PR DESCRIPTION
This pull request enhances the `createIssue` functionality by adding support for the Atlassian Document Format (ADF) in issue descriptions. Key changes include updating the schema validation, modifying the description handling logic, and introducing a utility for ADF conversion.

### Support for ADF in Descriptions:
* Updated `createIssueToolDescription` in `src/tools/createIssue.ts` to allow the `description` field to accept either plain text, markdown, or an ADF object. This ensures flexibility in how descriptions are provided. [[1]](diffhunk://#diff-2856ccaa9b52337f509ede6a22aa1df7f7f72c756982d45c78818a200df79bdaL42-R47) [[2]](diffhunk://#diff-2856ccaa9b52337f509ede6a22aa1df7f7f72c756982d45c78818a200df79bdaL77-R81)
* Added the `toADF` utility in `src/utils/adfUtils.ts` to convert plain text or markdown descriptions into ADF format if needed.
* Updated the `createIssue` function in `src/tools/createIssue.ts` to use the `toADF` utility for ensuring all descriptions are in ADF format before sending them to Jira. [[1]](diffhunk://#diff-2856ccaa9b52337f509ede6a22aa1df7f7f72c756982d45c78818a200df79bdaR98) [[2]](diffhunk://#diff-2856ccaa9b52337f509ede6a22aa1df7f7f72c756982d45c78818a200df79bdaL115-R120)

### Schema Validation Updates:
* Modified `JiraCreateIssueRequestSchema` in `src/validators/index.ts` to validate that the `description` field can be either a string or a valid ADF object. This ensures proper input validation.

### Miscellaneous:
* Adjusted the formatted response in `createIssue` to display either the plain text description or indicate that an ADF description was provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
	- Agora é possível criar issues utilizando descrições em texto simples, Markdown ou no formato Atlassian Document Format (ADF).

- **Aprimoramentos**
	- O campo de descrição aceita e valida tanto strings quanto objetos no formato ADF.
	- A apresentação da descrição de issues diferencia entre texto simples e descrições fornecidas em ADF.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->