### PR TITLE
Enforce ADF format for issue descriptions

### DIFF
--- a/src/tools/createIssue.ts
+++ b/src/tools/createIssue.ts
@@ -40,11 +40,8 @@ export const createIssueToolDescription = {
                 description: "The title/summary of the issue",
             },
             description: {
-                oneOf: [
-                    { type: "string", description: "Detailed description of the issue (plain text or markdown, will be converted to ADF)" },
-                    { type: "object", description: "ADF (Atlassian Document Format) object, see https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/" }
-                ],
-                description: "Detailed description of the issue. Accepts plain text, markdown, or Atlassian Document Format (ADF) object.",
+                type: "object",
+                description: "ADF (Atlassian Document Format) object, see https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/",
             },
             issueType: {
                 type: "string",
@@ -78,7 +75,7 @@ export const createIssueToolDescription = {
  * @param {string} args.apiToken - API token for authentication
  * @param {string} args.projectKey - The project key
  * @param {string} args.summary - Issue title/summary
- * @param {string|object} args.description - Issue description (plain text, markdown, or Atlassian Document Format object)
+ * @param {object} args.description - Issue description (ADF JSON object, Atlassian Document Format)
  * @param {string} [args.issueType] - Type of issue
  * @param {string} [args.assigneeName] - Name of the assignee
  * @param {string} [args.reporterName] - Name of the reporter
@@ -138,10 +135,10 @@ export async function createIssue(args: any) {
                 });
 
                 if (userResponse.data && userResponse.data.length > 0) {
-                    const assigneeUser = userResponse.data.find((user: any) => 
+                    const assigneeUser = userResponse.data.find((user: any) =>
                         user.displayName.toLowerCase() === assigneeName.toLowerCase()
                     ) || userResponse.data[0];
-                    
+
                     issuePayload.fields.assignee = {
                         id: assigneeUser.accountId
                     };
@@ -165,10 +162,10 @@ export async function createIssue(args: any) {
                 });
 
                 if (userResponse.data && userResponse.data.length > 0) {
-                    const reporterUser = userResponse.data.find((user: any) => 
+                    const reporterUser = userResponse.data.find((user: any) =>
                         user.displayName.toLowerCase() === reporterName.toLowerCase()
                     ) || userResponse.data[0];
-                    
+
                     issuePayload.fields.reporter = {
                         id: reporterUser.accountId
                     };
@@ -188,7 +185,7 @@ export async function createIssue(args: any) {
         });
 
         const createdIssue = response.data;
-        
+
         // Add the issue to a sprint if sprintId is provided
         if (sprintId && createdIssue.id) {
             try {
@@ -251,8 +248,6 @@ export async function createIssue(args: any) {
                 }
                 return '';
             }).join('\n');
-        } else if (typeof description === 'string') {
-            descriptionPreview = description;
         } else {
             descriptionPreview = '[ADF description provided]';
         }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,11 @@ export interface Project {
     id: string;
     key: string;
     name: string;
-    description?: string;
+    description?: {
+        type: 'doc';
+        version: number;
+        content: any[];
+    };
     lead?: User;
     style?: string;
     url?: string;
@@ -25,7 +29,11 @@ export interface Project {
 export interface IssueType {
     id: string;
     name: string;
-    description?: string;
+    description?: {
+        type: 'doc';
+        version: number;
+        content: any[];
+    };
     subtask?: boolean;
     avatarId?: number;
     iconUrl?: string;
@@ -34,7 +42,11 @@ export interface IssueType {
 export interface Component {
     id: string;
     name: string;
-    description?: string;
+    description?: {
+        type: 'doc';
+        version: number;
+        content: any[];
+    };
     lead?: User;
     assigneeType?: string;
     assignee?: User;
@@ -72,17 +84,25 @@ export interface Issue {
         created?: string;
         updated?: string;
         duedate?: string;
-        description?: string;
+        description?: {
+            type: 'doc';
+            version: number;
+            content: any[];
+        };
         components?: Component[];
         labels?: string[];
-        [key: string]: any; 
+        [key: string]: any;
     };
 }
 
 export interface ProjectRole {
     id: number;
     name: string;
-    description?: string;
+    description?: {
+        type: 'doc';
+        version: number;
+        content: any[];
+    };
     actors?: RoleActor[];
     scope?: {
         type: string;

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -63,19 +63,11 @@ export const JiraCheckUserIssuesRequestSchema = JiraApiRequestSchema.shape({
 export const JiraCreateIssueRequestSchema = JiraApiRequestSchema.shape({
     projectKey: yup.string().required("Project key is required"),
     summary: yup.string().required("Issue summary/title is required"),
-    description: yup.mixed()
-        .test('is-string-or-adf', 'Issue description must be a string or an Atlassian Document Format object', value => {
-            if (typeof value === 'string') return true;
-            if (typeof value === 'object' && value !== null) {
-                return (
-                    'type' in value && value.type === 'doc' &&
-                    'version' in value && value.version === 1 &&
-                    'content' in value && Array.isArray((value as any).content)
-                );
-            }
-            return false;
-        })
-        .required("Issue description is required"),
+    description: yup.object({
+        type: yup.string().oneOf(['doc']).required(),
+        version: yup.number().required(),
+        content: yup.array().required(),
+    }).required('Issue description (ADF) is required'),
     issueType: yup.string().oneOf(['Task', 'Bug', 'Story', 'Epic'], "Issue type must be one of: Task, Bug, Story, Epic").default("Task"),
     assigneeName: yup.string(),
     reporterName: yup.string(),

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -65,7 +65,7 @@ export const JiraCreateIssueRequestSchema = JiraApiRequestSchema.shape({
     summary: yup.string().required("Issue summary/title is required"),
     description: yup.object({
         type: yup.string().oneOf(['doc']).required(),
-        version: yup.number().required(),
+        version: yup.number().oneOf([1]).required(),
         content: yup.array().required(),
     }).required('Issue description (ADF) is required'),
     issueType: yup.string().oneOf(['Task', 'Bug', 'Story', 'Epic'], "Issue type must be one of: Task, Bug, Story, Epic").default("Task"),


### PR DESCRIPTION
Update the issue description handling to require an ADF (Atlassian Document Format) object across various interfaces and schemas. This change enhances consistency and compatibility with Jira's requirements, streamlining the issue creation process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Novos Recursos**
    - O campo de descrição agora aceita apenas objetos no formato Atlassian Document Format (ADF), permitindo descrições mais ricas e estruturadas.

- **Correções de Bugs**
    - Removido o suporte a descrições em texto simples ou markdown, evitando inconsistências no formato das descrições.

- **Documentação**
    - Atualizadas as descrições e exemplos para refletir o novo formato obrigatório de descrição em ADF.

- **Refatoração**
    - Padronização dos tipos e validações do campo de descrição em todas as interfaces e esquemas de validação.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->